### PR TITLE
feat: adds support for yarnpkg.com

### DIFF
--- a/content_yarn.js
+++ b/content_yarn.js
@@ -1,0 +1,12 @@
+const packageName = document.location.pathname.split('/package/')[1];
+const $readme = document.getElementById("readme");
+const $anchor = document.createElement('a');
+
+$anchor.setAttribute('href', `https://snyk.io/test/npm/${packageName}`);
+$anchor.innerHTML = `<div class="m-2"><img
+src="https://snyk.io/test/npm/${packageName}/badge.svg"
+alt="Known Vulnerabilities"
+data-canonical-src="https://snyk.io/test/npm/${packageName}"
+style="max-width:100%;"/></div>`;
+
+$readme.parentNode.insertBefore($anchor, $readme);

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,12 @@
       "https://github.com/*"
     ],
     "js": ["content_github.js", "badge.js"]
+  },
+  {
+    "matches": [
+      "https://yarnpkg.com/*/package/*"
+    ],
+    "js": ["content_yarn.js"]
   }
 ]
 }


### PR DESCRIPTION
Slightly different approach here I'm using the [Badges](https://snyk.io/docs/badges) directly. I couldn't quite understand why _not_ to use them 🙂 

Take a look when you can be great to hear your thoughts.