### PR TITLE
fix: cors on fetch badge request

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -62,7 +62,15 @@ browser.runtime.onMessage.addListener( (request, sender, sendResponse) => {
     return true;
 
   } else {
-    const badgeRequest = fetch(request.testPath + '/badge.svg');
+    const badgeRequest = fetch('https://us-central1-snyk-browser-extension.cloudfunctions.net/badge', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        url: request.testPath + '/badge.svg',
+      }),
+    });
 
     badgeRequest
       .then((response) => {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/aarlaud-snyk/snyk-chrome-extension/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Since moving to (fetch)[https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API] the badge request which was being parsed to provide the browser notifications stopped working. This was owing to there being no `Access-Control-Allow-Origin` being present on the resource. 

This PR updates the fetch request to load the badge via a Google Cloud Function which adds a relaxed `Access-Control-Allow-Origin` rule. Function source available here: https://github.com/thisislawatts/faas-cors

#### How should this be manually tested?

Can verify it's working as the Browser notifications will be functional.