### PR TITLE
feat: support client side navigation within npm

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,11 +33,12 @@
   "content_scripts": [
     {
       "matches": [
-        "https://www.npmjs.com/package/*"
+        "https://www.npmjs.com/package/*",
+        "https://www.npmjs.com/package/*/v/*"
       ],
       "js": [
-        "src/js/content/npm.js",
-        "src/js/badge.js"
+        "src/js/badge.js",
+        "src/js/content/npm.js"
       ]
     },
     {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,4 +1,4 @@
-var snykurl = 'snyk.io';
+const snykurl = 'snyk.io';
 
 const browser = window.msBrowser || window.browser || window.chrome;
 
@@ -25,6 +25,20 @@ function showSafeNotification(packageName, packageVersion = null) {
     priority: 0,
   });
 }
+
+const isValidNpmPackagePage = (str) => {
+  const pattern = new RegExp(/^https:\/\/www.npmjs.com\/package\//);
+  return pattern.test(str);
+};
+
+browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === 'loading' && isValidNpmPackagePage(changeInfo.url)) {
+    chrome.tabs.sendMessage(tabId, {
+      message: 'client-side-navigation',
+      url: changeInfo.url,
+    });
+  }
+});
 
 browser.runtime.onMessage.addListener( (request, sender, sendResponse) => {
   if (request.source === 'getsnykurl') {

--- a/src/js/content/npm.js
+++ b/src/js/content/npm.js
@@ -1,19 +1,29 @@
 /* global getBadge */
-const packageName = document.location.pathname.split('/')[2];
-const packageVersion = document.location.pathname.split('/')[4] || 'latest';
-const testPath = `https://snyk.io/test/npm/${packageName}/${packageVersion}`;
+function processNpmPackage() {
+  const packageName = document.location.pathname.split('/')[2];
+  const packageVersion = document.location.pathname.split('/')[4] || 'latest';
+  const testPath = `https://snyk.io/test/npm/${packageName}/${packageVersion}`;
 
-chrome.runtime.sendMessage({
-  source: 'npm',
-  packageName,
-  packageVersion,
-  testPath,
-}, () => {
-  const $anchor = document.createElement('a');
-  $anchor.setAttribute('href', `${testPath}`);
-  $anchor.innerHTML = getBadge(testPath);
+  chrome.runtime.sendMessage({
+    source: 'npm',
+    packageName,
+    packageVersion,
+    testPath,
+  }, () => {
+    const $anchor = document.createElement('a');
+    const $headingElement = document.querySelector('#readme h1') || document.querySelector('#readme > *:first-child');
+    $anchor.setAttribute('href', `${testPath}`);
+    $anchor.innerHTML = getBadge(testPath);
 
-  document
-    .querySelector('#readme h1')
-    .after($anchor);
+    $headingElement
+      .after($anchor);
+  });
+}
+
+processNpmPackage();
+
+chrome.runtime.onMessage.addListener((data) => {
+  if (data.message && data.message === 'client-side-navigation') {
+    processNpmPackage();
+  }
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/aarlaud-snyk/snyk-chrome-extension/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes #3. NPM are currently doing most of their navigation on the client side.

#### How should this be manually tested?

Steps to manually tests:

- Navigate to a package eg. express
- Click through to the versions tab
- Select an older version

The fix gets the browser notification and badge appearing on these pages.
